### PR TITLE
Merge 'single-detector' branch

### DIFF
--- a/include/gwat/waveform_util.h
+++ b/include/gwat/waveform_util.h
@@ -23,6 +23,15 @@ void create_coherent_GW_detection(
 	gen_params_base<T> *gen_params,
 	std::string generation_method,
 	std::complex<T> **responses);
+template <class T>
+void create_single_GW_detection(
+	std::complex<T> *response,	//< [out] Detector response \tilde{h}. Should be pre-allocated array of same length of frequencies
+	std::string detector,	//< Detector string name
+	T *frequencies,					//< Frequency array
+	int length,						//< Length of data (frequnecies and response)
+	gen_params_base<T> *gen_params,	//< Waveform parameters
+	std::string generation_method	//< Waveform generation method
+);
 template<class T>
 void create_coherent_GW_detection_reuse_WF(
 	std::string *detectors,

--- a/src/adaptivelikelihoods.cpp
+++ b/src/adaptivelikelihoods.cpp
@@ -393,16 +393,30 @@ double RelativeBinningLikelihood::log_likelihood(
     }
 
     // Time shift
-    // TODO: How important is shifting tc as in MCMC_likelihood_extrinsic?
+    // TODO: How important is shifting tc as in MCMC_likelihood_extrinsic? If not, delete this block.
     //double T = duration;
     //double tc_ref = T - params->tc;
     //params->tc = tc_ref;
 
     // Obtain the data
-    create_coherent_GW_detection(
-        detectors, num_detectors, frequencies, data_lengths, reuse_WF,
-        params, generation_method, responses
-    );
+    if (num_detectors == 1)
+    {
+        create_single_GW_detection(
+            responses[0],
+            detectors[0],
+            frequencies[0],
+            data_lengths[0],
+            params,
+            generation_method
+        );
+    }
+    else
+    {
+        create_coherent_GW_detection(
+            detectors, num_detectors, frequencies, data_lengths, reuse_WF,
+            params, generation_method, responses
+        );
+    }
 
     // Calculate likelihood
     double logL = 0.;

--- a/src/mcmc_gw.cpp
+++ b/src/mcmc_gw.cpp
@@ -2511,8 +2511,22 @@ double MCMC_likelihood_extrinsic(bool save_waveform,
 		responses[i] = new std::complex<double>[data_length[i]];
 	}
 	//parameters->tc = -(parameters->tc);	
-	create_coherent_GW_detection(detectors, num_detectors, frequencies,data_length, save_waveform, parameters, generation_method, responses);
-
+	if (num_detectors == 1)
+	{
+		create_single_GW_detection(
+            responses[0],
+            detectors[0],
+            frequencies[0],
+            data_length[0],
+            parameters,
+            generation_method
+        );
+	}
+	else
+	{
+		create_coherent_GW_detection(detectors, num_detectors, frequencies,data_length, save_waveform, parameters, generation_method, responses);
+	}
+	
 	if (QuadMethod == NULL)
 	{
 		// Scott's way

--- a/src/waveform_util.cpp
+++ b/src/waveform_util.cpp
@@ -125,6 +125,41 @@ double data_snr(double *frequencies,
 	return sqrt(inner_prod);
 
 }
+
+template <class T>
+void create_single_GW_detection(
+	std::complex<T> *response,
+	std::string detector,
+	T *frequencies,
+	int length,
+	gen_params_base<T> *gen_params,
+	std::string generation_method
+)
+{
+	waveform_polarizations<T> wp;
+	assign_polarizations(generation_method, &wp);
+	wp.allocate_memory(length);
+
+	fourier_waveform(frequencies, length, &wp,generation_method, gen_params);
+	fourier_detector_response_equatorial(
+		frequencies, length,&wp, response,
+		gen_params->RA,gen_params->DEC,gen_params->psi,
+		gen_params->gmst,(T *)NULL, gen_params->LISA_alpha0,gen_params->LISA_phi0, gen_params->theta_l, gen_params->phi_l,
+		detector
+	);
+
+	wp.deallocate_memory();
+}
+
+template void create_single_GW_detection<double>(
+	std::complex<double> *,
+	std::string,
+	double *,
+	int,
+	gen_params_base<double> *,
+	std::string
+);
+
 template <class T>
 void create_coherent_GW_detection(
 	std::string *detectors,


### PR DESCRIPTION
This branch has several new features that were worked on in the 'relbin' branch as well, namely:

- A new Detector called `generic', which is simply a static, stationary detector at the coordinate origin.
- Likelihood calculator can now use the PN-based "relative binning", as known in BILBY.
- Arbitrary likelihood calculator: the likelihood calculation can now be done with any user-defined function. Ask Nijaid for more info.
- Arbitrary inner product calculator: the inner product between two data can now be done with any user-defined function. This forms part of the new likelihood feature.

The new likelihood feature can only be used if your inference type is _not_ "intrinsic". Making sure there is a likelihood class that marginalizes over extrinsic parameters in order to be used as "intrinsic" will need to be planned carefully in face of how the `eval` function of the sampler is currently written.

This has necessitated rewriting certain basic structures in GWAT, such as `gen_params` and `mod_struct`. It is advised that all development branches incorporate these changes.